### PR TITLE
Fix/97

### DIFF
--- a/backend/flaskr/handlers/team_handler.py
+++ b/backend/flaskr/handlers/team_handler.py
@@ -53,7 +53,7 @@ def create_fast_team_with_users():
         return error_res
 
     team_name = body["name"]
-    invited_members = body["members"]
+    invited_members = set(filter(lambda x: x != body["owner"], body["members"]))
 
     for member_name in invited_members:
         error_res = add_user_to_team(member_name, team_name)
@@ -78,7 +78,7 @@ def create_team():
         return error_res
 
     team_name = body["name"]
-    invited_members = body["members"]
+    invited_members = set(filter(lambda x: x != body["owner"], body["members"]))
 
     from ..model.utils import invite_user_to_team
     for invited_member_name in invited_members:

--- a/backend/flaskr/handlers/template_handler.py
+++ b/backend/flaskr/handlers/template_handler.py
@@ -109,3 +109,11 @@ def assign_template_to_team():
     pending_forms_dao.insert_many(forms_to_insert)
 
     return jsonify({"confirmation": "OK"})
+
+
+@app.route("/templates/get_templates/<username>/", methods=["GET"])
+def get_user_templates(username):
+    template_dao = TemplateDAO()
+    user_templates = template_dao.find_all_for_owner(username)
+
+    return jsonify({"templates": [x.data for x in user_templates]})

--- a/backend/flaskr/handlers/template_handler.py
+++ b/backend/flaskr/handlers/template_handler.py
@@ -112,6 +112,7 @@ def assign_template_to_team():
 
 
 @app.route("/templates/get_templates/<username>/", methods=["GET"])
+@auth_required
 def get_user_templates(username):
     template_dao = TemplateDAO()
     user_templates = template_dao.find_all_for_owner(username)

--- a/backend/flaskr/handlers/user_handler.py
+++ b/backend/flaskr/handlers/user_handler.py
@@ -136,5 +136,8 @@ def get_user_teams(username):
     if user is None:
         return mk_error("User with given username does not exist!")
 
-    teams = user.teams
-    return jsonify({"teams": teams})
+    try:
+        teams = user.teams
+        return jsonify({"teams": teams})
+    except KeyError:
+        return jsonify({"teams": []})


### PR DESCRIPTION
- endpoint for reading templates owned by user
- getting team list for user which has no teams assigned now returns an empty list
- during team creation it is checked if owner is in members list, and the confirmation link is not sent to him
- some tests